### PR TITLE
fix(base): Ensure all console log are visible

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@ import {moduleName as oneName} from './module-one';
 import {moduleName as twoName} from './module-two';
 import {moduleName as threeName} from './module-three';
 
-export const run = () =>
+export const run = () => {
     console.log(oneName);
     console.log(twoName);
     console.log(threeName);
+}


### PR DESCRIPTION
Due to a missing parenthesis, the console.log in base modules were not visible. Change to code in
order to display all the console.log

re #7